### PR TITLE
Fixed MPI bug in ROCM

### DIFF
--- a/src/papi/papi_wrapper.sh
+++ b/src/papi/papi_wrapper.sh
@@ -256,7 +256,7 @@ _parse_papi_native_avail() {
                 else
                     # Otherwise, take combinations of the event and modifiers.
                     while [ "$(array_len "$modifiers")" -ne 0 ]; do
-                        mod=$(array_get_last "$modifiers")
+                        mod=$(array_get "$modifiers" "-1")
                         modifiers=$(array_pop "$modifiers")
                         _print_papi_event "$mode" "${event_name}${mod}" "$unit"
                     done
@@ -290,7 +290,7 @@ _get_papi_native_avail() {
     events=""
 
     while [ "$(array_len "$components")" -ne 0 ]; do
-        component=$(array_get_last "$components")
+        component=$(array_get "$components" "-1")
         components=$(array_pop "$components")
         events=$(papi_native_avail -i "$component")
 

--- a/src/rocm/rocm_wrapper.sh
+++ b/src/rocm/rocm_wrapper.sh
@@ -34,7 +34,7 @@ _get_rocm_power_measurement() {
     | while IFS=',' read -r device power; do
         # Skip N/A value.
         case $power in
-            N/A*) ;;
+            N/A*) printf '%s %s\n' "$device" "0" ;;
             *) printf '%s %s\n' "$device" "$power" ;;
         esac
     done
@@ -76,7 +76,7 @@ EOF
     while kill -0 "$child_pid" 2>/dev/null; do
         i=0
         while IFS=' ' read -r device power; do
-            # Only update values if there is a measurement.
+            # Only update value of this card if there is a measurement.
             if [ -n "$power" ]; then
                 watts="$power"
                 energy_consumed=$(echo "$watts * $poll_time_s" | bc -l)

--- a/src/rocm/rocm_wrapper.sh
+++ b/src/rocm/rocm_wrapper.sh
@@ -76,11 +76,14 @@ EOF
     while kill -0 "$child_pid" 2>/dev/null; do
         i=0
         while IFS=' ' read -r device power; do
-            watts="$power"
-            energy_consumed=$(echo "$watts * $poll_time_s" | bc -l)
-            cur_energy=$(array_get "$energies" "$i")
-            energies=$(array_set "$energies" "$i" \
-                "$(echo "$cur_energy + $energy_consumed" | bc -l)")
+            # Only update values if there is a measurement.
+            if [ -n "$power" ]; then
+                watts="$power"
+                energy_consumed=$(echo "$watts * $poll_time_s" | bc -l)
+                cur_energy=$(array_get "$energies" "$i")
+                energies=$(array_set "$energies" "$i" \
+                    "$(echo "$cur_energy + $energy_consumed" | bc -l)")
+            fi
             i=$((i+1))
         done <<EOF
 $(_get_rocm_power_measurement)

--- a/src/utils/array_utils.sh
+++ b/src/utils/array_utils.sh
@@ -10,7 +10,6 @@
 #   - Get array length:             array_len <array>
 #   - Add value to top:             array_push <array> <value>
 #   - Delete and export top value:  array_pop <array>
-#   - Get last value:               array_get_last <array>
 #   - Get the value at a index:     array_get <array> <index>
 #   - Set the value at a index:     array_set <array> <index> <new_value>
 #   - Delete array value:           array_delete <array> <index>
@@ -72,24 +71,8 @@ array_pop() {
             prev = $0
         }
         END {
-            # do not print the last non-empty line, which is what we remove.
+            # Do not print the last non-empty line, as it is what we remove.
         }
-    '
-}
-
-# Gets the last array value.
-#   Usage:    array_get_last <array>
-array_get_last() {
-    # Sanitize input.
-    if [ -z "$1" ]; then
-        print_error "<array_get> No array passed."
-        return 1
-    fi
-
-    # Print only last element.
-    printf '%s\n' "$1" | awk '
-        length($0) { last = $0 }
-        END { if (length(last)) print last }
     '
 }
 
@@ -114,7 +97,7 @@ array_get() {
             lines[NR] = $0
         }
         END {
-            # Resolve index
+            # Resolve index sign.
             if (idx >= 0) {
                 target = idx + 1
             } else {

--- a/src/utils/array_utils.sh
+++ b/src/utils/array_utils.sh
@@ -108,14 +108,26 @@ array_get() {
         return 1
     fi
 
-    # Convert the 0-based index to 1-based.
-    idx=$(( $2 + 1 ))
+    # Convert the 0-based index to 1-based for awk usage.
+    printf '%s\n' "$1" | awk -v idx="$2" '
+        {
+            lines[NR] = $0
+        }
+        END {
+            # Resolve index
+            if (idx >= 0) {
+                target = idx + 1
+            } else {
+                target = NR + idx + 1
+            }
 
-    # Print only the requested line.
-    printf '%s\n' "$1" | awk -v idx="$idx" '
-        NR == idx {
-            print
-            exit
+            # Return nothing if index out of bounds.
+            if (target < 1 || target > NR) {
+                verbose_echo print_error "<array_get> Index out of bounds."
+                exit 1
+            }
+
+            print lines[target]
         }
     '
 }

--- a/src/utils/mpi_utils.sh
+++ b/src/utils/mpi_utils.sh
@@ -35,7 +35,7 @@ EOF
     i=1
     while [ "$i" -lt "$MPI_SIZE" ]; do
         # Aggregate the values of this rank for each event.
-        rank_input=$(cat "$tmp_dir/rank_$((i - 1))_$dtype.out")
+        rank_input=$(cat "$tmp_dir/rank_${i}_$dtype.out")
         while IFS= read -r line; do
             mpi_total_array=$(array_push "$mpi_total_array" "$line")
         done <<EOF
@@ -69,7 +69,7 @@ EOF
     # Aggregate the collected values of all ranks.
     i=1
     while [ "$i" -lt "$MPI_SIZE" ]; do
-        rank_input=$(cat "$tmp_dir/rank_$((i - 1))_$dtype.out")
+        rank_input=$(cat "$tmp_dir/rank_${i}_$dtype.out")
 
         # Aggregate the values of this rank for each event.
         j=0

--- a/src/utils/mpi_utils.sh
+++ b/src/utils/mpi_utils.sh
@@ -171,7 +171,10 @@ mpi_gather() {
         tmp_dir="tmp.$job"
         mkdir -p "$tmp_dir"
         printf "%s\n" "$energy" >"$tmp_dir/rank_${RANK}_energy.out"
-        verbose_echo print_info "Total Energy Task: $(array_get "$energy" "-1")"
+
+        # Report task's energy consumption in VERBOSE mode.
+        line="Task's total energy consumption: $(array_get "$energy" "-1")"
+        verbose_echo print_info "$line"
 
         # Only store labels if in concatenate mode.
         if [ "$mode" = "concatenate" ]; then

--- a/src/utils/mpi_utils.sh
+++ b/src/utils/mpi_utils.sh
@@ -171,6 +171,7 @@ mpi_gather() {
         tmp_dir="tmp.$job"
         mkdir -p "$tmp_dir"
         printf "%s\n" "$energy" >"$tmp_dir/rank_${RANK}_energy.out"
+        verbose_echo print_info "Total Energy Task: $(array_get "$energy" "-1")"
 
         # Only store labels if in concatenate mode.
         if [ "$mode" = "concatenate" ]; then

--- a/tests/test_utils_array.sh
+++ b/tests/test_utils_array.sh
@@ -51,61 +51,6 @@ test_array_push() {
     fi
 }
 
-# Test array_get_last.
-test_array_get_last() {
-    # Setup default array.
-    arr="$(_setup_test_array)"
-
-    # Check for first pop.
-    top_val=$(array_get_last "$arr")
-    if [ "$top_val" != "val2" ]; then
-        printf "Top value incorrect: '%s' != val2.\n" "$top_val" >&2
-        return 1
-    fi
-}
-
-# Test array_pop.
-test_array_pop() {
-    # Setup default array.
-    arr="$(_setup_test_array)"
-
-    # Check for first pop.
-    top_val=$(array_get_last "$arr")
-    arr=$(array_pop "$arr")
-    if [ "$top_val" != "val2" ]; then
-        printf "Top value incorrect: '%s' != val2.\n" "$top_val" >&2
-        return 1
-    elif [ "$(array_len "$arr")" -ne 2 ]; then
-        printf "array length is incorrect after first pop: '%s' != 2.\n" \
-            "$(array_len "$arr")" >&2
-        return 1
-    fi
-
-    # Check for second pop.
-    top_val=$(array_get_last "$arr")
-    arr=$(array_pop "$arr")
-    if [ "$top_val" != "val1" ]; then
-        printf "Top value incorrect: '%s' != val1.\n" "$top_val" >&2
-        return 1
-    elif [ "$(array_len "$arr")" -ne 1 ]; then
-        printf "array length is incorrect after second pop: '%s' != 1.\n" \
-            "$(array_len "$arr")" >&2
-        return 1
-    fi
-
-    # Check for third pop.
-    top_val=$(array_get_last "$arr")
-    arr=$(array_pop "$arr")
-    if [ "$top_val" != "val0" ]; then
-        printf "Top value incorrect: '%s' != val0.\n" "$top_val" >&2
-        return 1
-    elif [ "$(array_len "$arr")" -ne 0 ]; then
-        printf "array length is incorrect after third pop: '%s' != 0.\n" \
-            "$(array_len "$arr")" >&2
-        return 1
-    fi
-}
-
 # Test array_get.
 test_array_get() {
     # Setup default array.
@@ -174,6 +119,48 @@ test_array_set() {
     if [ "$val" != "new1" ]; then
         printf \
             "The overwritten value is incorrect: '%s' != 'new1'.\n" "$val" >&2
+        return 1
+    fi
+}
+
+# Test array_pop.
+test_array_pop() {
+    # Setup default array.
+    arr="$(_setup_test_array)"
+
+    # Check for first pop.
+    top_val=$(array_get "$arr" "-1")
+    arr=$(array_pop "$arr")
+    if [ "$top_val" != "val2" ]; then
+        printf "Top value incorrect: '%s' != val2.\n" "$top_val" >&2
+        return 1
+    elif [ "$(array_len "$arr")" -ne 2 ]; then
+        printf "array length is incorrect after first pop: '%s' != 2.\n" \
+            "$(array_len "$arr")" >&2
+        return 1
+    fi
+
+    # Check for second pop.
+    top_val=$(array_get "$arr" "-1")
+    arr=$(array_pop "$arr")
+    if [ "$top_val" != "val1" ]; then
+        printf "Top value incorrect: '%s' != val1.\n" "$top_val" >&2
+        return 1
+    elif [ "$(array_len "$arr")" -ne 1 ]; then
+        printf "array length is incorrect after second pop: '%s' != 1.\n" \
+            "$(array_len "$arr")" >&2
+        return 1
+    fi
+
+    # Check for third pop.
+    top_val=$(array_get "$arr" "-1")
+    arr=$(array_pop "$arr")
+    if [ "$top_val" != "val0" ]; then
+        printf "Top value incorrect: '%s' != val0.\n" "$top_val" >&2
+        return 1
+    elif [ "$(array_len "$arr")" -ne 0 ]; then
+        printf "array length is incorrect after third pop: '%s' != 0.\n" \
+            "$(array_len "$arr")" >&2
         return 1
     fi
 }

--- a/tests/test_utils_array.sh
+++ b/tests/test_utils_array.sh
@@ -183,6 +183,7 @@ test_array_delete() {
 # Test array_foreach.
 test_array_foreach() {
     # Define printing function to be used. Note it is globally defined!
+    # shellcheck disable=SC2329
     print_string() {
         printf '%s\n' "$1"
     }

--- a/tests/test_utils_array.sh
+++ b/tests/test_utils_array.sh
@@ -131,6 +131,27 @@ test_array_get() {
         printf "The third value is incorrect: '%s' != val2.\n" "$val" >&2
         return 1
     fi
+
+    # Check for the third value with negative indexing.
+    val=$(array_get "$arr" "-1")
+    if [ "$val" != "val2" ]; then
+        printf "The third value via negative indexing is incorrect: '%s' != val2.\n" "$val" >&2
+        return 1
+    fi
+
+    # Check for the second value with negative indexing.
+    val=$(array_get "$arr" "-2")
+    if [ "$val" != "val1" ]; then
+        printf "The second value via negative indexing is incorrect: '%s' != val1.\n" "$val" >&2
+        return 1
+    fi
+
+    # Check for the first value with negative indexing.
+    val=$(array_get "$arr" "-3")
+    if [ "$val" != "val0" ]; then
+        printf "The first value via negative indexing is incorrect: '%s' != val0.\n" "$val" >&2
+        return 1
+    fi
 }
 
 # Test array_set.


### PR DESCRIPTION
Closes #5   

Change log:

- Fixed bug with ROCM energy collection reading `N/A` values
- Introduced negative indexing for `array_get`
- Removed `array_get_last` as it's now replaced with negative indexing through `array_get`
- Fixed 1-off bug in gathering MPI results